### PR TITLE
Add link to Libre Health GitHub repository in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Libre Health
 
-Pebble companion app for Libre Health, the open-source, local-only health tracker for Android.
+Pebble companion app for Libre Health, the [open-source, local-only health tracker for Android](https://github.com/peerdavid/libre-health).
 
 Warning: Requires the LibreHealth Android companion app. There you can connect to pebble by clicking the upper right dots, then "Pebble".
 


### PR DESCRIPTION
Updated README to include a link to the Libre Health GitHub repository.